### PR TITLE
combine newsletters with latest blog posts

### DIFF
--- a/content/newsletters/2021-11.md
+++ b/content/newsletters/2021-11.md
@@ -1,5 +1,9 @@
 ---
-date: 2021-11-17T12:40:00Z
+title: "CFFL November Newsletter"
+date: 2021-11-17
+preview_image: /images/hugo/extractive_summarization_pipeline-1637184569.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # November 2021

--- a/content/newsletters/2021-12.md
+++ b/content/newsletters/2021-12.md
@@ -1,6 +1,11 @@
 ---
+title: "CFFL December Newsletter"
 date: 2021-12-09
+preview_image: /images/hugo/action_forecasting_example-1639168656.png
+post_type: Newsletter
+# external_url: 
 ---
+
 # December 2021
 
 Welcome to the December edition of the Cloudera Fast Forward Labs newsletter. This month we dive into the world of Video Understanding and share our favorite reads. 

--- a/content/newsletters/2022-01.md
+++ b/content/newsletters/2022-01.md
@@ -1,6 +1,11 @@
 ---
+title: "CFFL January Newsletter"
 date: 2022-01-21
+preview_image: /images/hugo/snowflakes-1642805048.png
+post_type: Newsletter
+# external_url: 
 ---
+
 # January 2022
 
 Welcome to the January edition of the Cloudera Fast Forward Labs newsletter.  This month we provide a glimpse of our next research topic, talk about the uniqueness of snowflakes, and share what we’ve been reading this month. 

--- a/content/newsletters/2022-02.md
+++ b/content/newsletters/2022-02.md
@@ -1,6 +1,11 @@
 ---
+title: "CFFL February Newsletter"
 date: 2022-02-17
+preview_image: /images/hugo/video_convolution_example-1645140017.png
+post_type: Newsletter
+# external_url: 
 ---
+
 # February 2022
 
 Welcome to the February edition of the Cloudera Fast Forward Labs newsletter.  This month we dive deeper into the world of video convolutions, share some applied machine learning prototypes we’ve built, and discuss our top reads. 

--- a/content/newsletters/2022-03.md
+++ b/content/newsletters/2022-03.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL March Newsletter"
 date: 2022-03-22
+preview_image: /images/hugo/tst_definition-1647958795.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # March 2022

--- a/content/newsletters/2022-04.md
+++ b/content/newsletters/2022-04.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL April Newsletter"
 date: 2022-04-10
+preview_image: /images/hugo/transfer-learning-pipeline-1649637022.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # April 2022

--- a/content/newsletters/2022-05.md
+++ b/content/newsletters/2022-05.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL May Newsletter"
 date: 2022-05-18
+preview_image: /images/hugo/fig4-tst2.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # May 2022

--- a/content/newsletters/2022-06.md
+++ b/content/newsletters/2022-06.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL June Newsletter"
 date: 2022-06-23
+preview_image: /images/hugo/recommendation_models-1656022871.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # June 2022

--- a/content/newsletters/2022-07.md
+++ b/content/newsletters/2022-07.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL July Newsletter"
 date: 2022-07-22
+preview_image: /images/hugo/image3-tst3.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # July 2022

--- a/content/newsletters/2022-08.md
+++ b/content/newsletters/2022-08.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL August Newsletter"
 date: 2022-08-18
+preview_image: /images/hugo/self_portrait-1660863172.jpeg
+post_type: Newsletter
+# external_url: 
 ---
 
 # August 2022

--- a/content/newsletters/2022-09.md
+++ b/content/newsletters/2022-09.md
@@ -1,5 +1,9 @@
 ---
+title: "CFFL September Newsletter"
 date: 2022-09-21
+preview_image: /images/hugo/tst_bart_cover-1663888335.png
+post_type: Newsletter
+# external_url: 
 ---
 
 # September 2022

--- a/layouts/_default/section.html
+++ b/layouts/_default/section.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-{{ $pages := where .Site.RegularPages.ByDate.Reverse "Section" "posts" }}
+{{ $pages := .Site.RegularPages.ByDate.Reverse}}
 {{ $paginator := .Paginate $pages }}
 
 <div class="container">

--- a/layouts/partials/latest_posts.html
+++ b/layouts/partials/latest_posts.html
@@ -1,4 +1,4 @@
-{{ $pages := where .Site.RegularPages.ByDate.Reverse "Section" "posts" }}
+{{ $pages := .Site.RegularPages.ByDate.Reverse}}
 
 <h2 class="clear">Latest posts</h2>
 <div class="spacer"></div>
@@ -21,7 +21,7 @@
     let $load_more = document.getElementById('load_more')
     let next_page = 2
     $load_more.addEventListener('click', () => {
-      fetch(`/posts/page/${next_page}.html`).then(r =>r.text()).then(r => {
+      fetch(`/newsletters/page/${next_page}.html`).then(r =>r.text()).then(r => {
         let el = document.createElement('html')
         el.innerHTML = r
         next_page += 1


### PR DESCRIPTION
This commit ensures that CFFL Monthly newsletters show up in the Latest Posts feed, as well as when clicking on the "load more" button at the bottom of the Latest Posts section. 

Past monthly newsletters through November 2021 have had their markdown modified to include a more description yaml header in order to guarantee proper formatting. 